### PR TITLE
Add NSGA-II baseline on nominal objectives

### DIFF
--- a/experiments/experiment_v1/main.py
+++ b/experiments/experiment_v1/main.py
@@ -25,6 +25,7 @@ from botorch.utils import draw_sobol_samples
 from botorch.utils.transforms import unnormalize
 from botorch.test_functions.base import ConstrainedBaseTestProblem
 from torch import Tensor
+from pymoo.algorithms.moo.nsga2 import NSGA2
 
 from robust_mobo.experiment_utils import (
     generate_initial_data,
@@ -51,6 +52,7 @@ supported_labels = [
     "ref_mvar_nehvi",
     "sobol",
     "cas",
+    "nsgaii",
 ]
 
 
@@ -219,6 +221,11 @@ def main(
             all_mvar_hvs = torch.tensor([initial_mvar_hv], dtype=dtype)
 
     # BO loop for as many iterations as needed.
+    if label == "nsgaii":
+        nsgaii_algorithm = get_nsgaii(X_init=X, Y_init=Y, base_function=base_function)
+        # set iterations based on nsga-ii population size
+        iterations = batch_size * iterations // nsgaii_algorithm.pop_size
+
     for i in range(existing_iterations, iterations):
         print(
             f"Starting label {label}, seed {seed}, iteration {i}, "
@@ -230,14 +237,27 @@ def main(
 
         if label == "sobol":
             candidates = (
-                draw_sobol_samples(
-                    bounds=standard_bounds,
-                    n=1,
-                    q=batch_size,
-                )
+                draw_sobol_samples(bounds=standard_bounds, n=1, q=batch_size,)
                 .squeeze(0)
                 .to(**tkwargs)
             )
+        elif label == "nsgaii":
+            # do the next iteration
+            if Y.shape[0] > n_initial_points:
+                last_X = pop.get("X")
+                n_new_points = last_X.shape[0]
+                pop.set("F", Y[:, -n_new_points:].cpu().numpy())
+
+                # for constraints
+                if is_constrained:
+                    pop.set("G", Y_con[:, -n_new_points:].cpu().numpy())
+                # this line is necessary to set the CV and feasbility status - even for unconstrained
+                set_cv(pop)
+                # returned the evaluated individuals which have been evaluated or even modified
+            nsgaii_algorithm.tell(infills=pop)
+            # generate new candidates
+            nsgaii_algorithm.ask()
+            candidates = torch.from_numpy(pop.get("X")).to(X)
         else:
             # Generate the perturbations.
             perturbation_set = get_perturbations(

--- a/robust_mobo/nsgaii_utils.py
+++ b/robust_mobo/nsgaii_utils.py
@@ -19,19 +19,20 @@ from pymoo.util.termination.no_termination import NoTermination
 
 
 def get_nsgaii(X_init: Tensor, Y_init: Tensor, base_function: BaseTestProblem) -> NSGA2:
+    is_constrained = isinstance(base_function, ConstrainedBaseTestProblem)
     pymoo_problem = Problem(
-        n_var=_problem.dim,
-        n_obj=_problem.num_objectives,
-        n_constr=_problem.num_constraints,
-        xl=np.zeros(_problem.dim),
-        xu=np.ones(_problem.dim),
+        n_var=base_function.dim,
+        n_obj=base_function.num_objectives,
+        n_constr=base_function.num_constraints if is_constrained else 0,
+        xl=np.zeros(base_function.dim),
+        xu=np.ones(base_function.dim),
     )
-    pop = Population.new("X", X_init.numpy())
-    # objectives
-    pop.set("F", Y_init[:, : base_function.num_objectives].numpy())
-    if isinstance(base_function, ConstrainedBaseTestProblem):
-        # constraints
-        pop.set("G", Y_init[:, base_function.num_objectives :].numpy())
+    pop = Population.new("X", X_init.cpu().numpy())
+    # pymoo minimizes objectives
+    pop.set("F", -Y_init[:, : base_function.num_objectives].cpu().numpy())
+    if is_constrained:
+        # negative constraint slack implies feasibility
+        pop.set("G", -Y_init[:, base_function.num_objectives :].cpu().numpy())
     algorithm = NSGA2(pop_size=10, sampling=pop)
     # let the algorithm object never terminate and let the loop control it
     termination = NoTermination()

--- a/robust_mobo/nsgaii_utils.py
+++ b/robust_mobo/nsgaii_utils.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+r"""
+NSGA-II utilities
+"""
+from typing import Dict
+from torch import Tensor
+import torch
+import numpy as np
+from pymoo.core.problem import Problem
+from pymoo.core.population import Population
+from pymoo.algorithms.moo.nsga2 import NSGA2
+from botorch.test_functions.base import BaseTestProblem, ConstrainedBaseTestProblem
+from pymoo.util.termination.no_termination import NoTermination
+
+
+def get_nsgaii(X_init: Tensor, Y_init: Tensor, base_function: BaseTestProblem) -> NSGA2:
+    pymoo_problem = Problem(
+        n_var=_problem.dim,
+        n_obj=_problem.num_objectives,
+        n_constr=_problem.num_constraints,
+        xl=np.zeros(_problem.dim),
+        xu=np.ones(_problem.dim),
+    )
+    pop = Population.new("X", X_init.numpy())
+    # objectives
+    pop.set("F", Y_init[:, : base_function.num_objectives].numpy())
+    if isinstance(base_function, ConstrainedBaseTestProblem):
+        # constraints
+        pop.set("G", Y_init[:, base_function.num_objectives :].numpy())
+    algorithm = NSGA2(pop_size=10, sampling=pop)
+    # let the algorithm object never terminate and let the loop control it
+    termination = NoTermination()
+
+    # create an algorithm object that never terminates
+    algorithm.setup(pymoo_problem, termination=termination, seed=0)
+
+    return algorithm

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ requirements = [
     "matplotlib",
     "sklearn",
     "joblib",
+    "pymoo",
 ]
 
 dev_requires = [


### PR DESCRIPTION
This runs NSGA-II with a pop size of 10 on the nominal objectives. The implementation supports constraints. It requires that the benchmark be run with a total number of evaluations (not including the initialization) that is divisible by 10: i.e. batch_size * iterations % 10 == 0